### PR TITLE
Fix gh-action for push

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Build
-    if: "! contains(toJSON(github.event.pull_request.title), '[skip-ci]')"
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Info :book: 
Pipeline needs to update chart version and it doesnt skip ci if commit messages contain [skip-ci] due to wrong if statement causing a never ending loop of gh-actions.