### PR TITLE
Add env var directly to ssh agent so it doesnt remove the line space

### DIFF
--- a/clustertask/push-main-tag/templates/clustertask.yaml
+++ b/clustertask/push-main-tag/templates/clustertask.yaml
@@ -62,14 +62,11 @@ spec:
             git config --global user.email stakater-tekton-bot@stakater.com
             mkdir ~/.ssh
             ls -a ~/
-            > ~/.ssh/id_rsa
             > ~/.ssh/known_hosts
             ls -a ~/.ssh
-            echo $APPLICATION_REPO_SSH_TOKEN >> ~/.ssh/id_rsa
             eval `ssh-agent -s`
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-            chmod 600  ~/.ssh/id_rsa
-            ssh-add ~/.ssh/id_rsa
+            ssh-add - <<< ${APPLICATION_REPO_SSH_TOKEN}
           fi
             git tag -am "Bump version to $(params.IMAGE_TAG)" $(params.IMAGE_TAG)
             git push --tags


### PR DESCRIPTION
The line spaces in the private key were being removed when it was being copied to a file. Adding it directly to ssh agent fixes the issue.