### PR TITLE
[create-environment] Use starting characters of first commit instead of ending

### DIFF
--- a/clustertask/create-environment/templates/clustertask.yaml
+++ b/clustertask/create-environment/templates/clustertask.yaml
@@ -67,7 +67,7 @@ spec:
             NAMESPACE_LABELS=`awk '{printf "    %s\n", $0}' < $(workspaces.output.path)/environment-workspace/temp_namespace_labels`
             SECRET_REF=`awk '{printf "          %s\n", $0}' < $(workspaces.output.path)/environment-workspace/temp_secret_ref`
             CHART_PATH=`yq e '.application.chart_path' $(workspaces.output.path)/environment-workspace/tronador.yaml`
-            PR_FIRST_COMMIT_HASH=`curl $(params.PULL_REQUEST_COMMITS_API) | jq -r 'first.sha' | tail -c 8`
+            PR_FIRST_COMMIT_HASH=`curl $(params.PULL_REQUEST_COMMITS_API) | jq -r 'first.sha' | head -c 8`
             ENVIRONMENT_NAME=`echo "pr-$(params.PR_NUMBER)-$(params.REPO_NAME)" | tr '[:upper:]' '[:lower:]' | tr " /._" -`
             # namespace length limit is 63 characters
             ENVIRONMENT_NAME=${ENVIRONMENT_NAME:0:54}-${PR_FIRST_COMMIT_HASH}


### PR DESCRIPTION
Use starting characters of first commit instead of ending