### PR TITLE
Add token as an optional workspace

### DIFF
--- a/clustertask/buildah/templates/clustertask.yaml
+++ b/clustertask/buildah/templates/clustertask.yaml
@@ -62,10 +62,6 @@ spec:
       description: Current version of the application/image in dev.
       name: CURRENT_GIT_TAG
       type: string
-    - default: ''
-      description: Name of secret containing token to be used in the dockerfile for cloning other github dependenncies.
-      name: GIT_DEPENDENCY_TOKEN
-      type: string      
   results:
     - description: Digest of the image just built.
       name: IMAGE_DIGEST
@@ -73,14 +69,19 @@ spec:
     - image: $(params.BUILDER_IMAGE)
       name: build
       resources: {}
-      env:
-        - name: GIT_DEPENDENCY_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: token
-              name: $(params.GIT_DEPENDENCY_TOKEN)
-
       script: >
+        
+        FILE=../buildah-git_dependency-token/token 
+
+        if [ -f "$FILE" ]; then
+          echo "$FILE exists."
+          GIT_DEPENDENCY_TOKEN=`cat $FILE` 
+          echo $GIT_DEPENDENCY_TOKEN
+        else 
+          echo "$FILE does not exist."
+          GIT_DEPENDENCY_TOKEN=''
+        fi
+        
         buildah pull docker://$(params.IMAGE_REGISTRY):$(params.CURRENT_GIT_TAG) || Image_unavailable=$?
 
         if [[ $(params.BUILD_IMAGE) == true ||  $Image_unavailable != ''
@@ -134,3 +135,5 @@ spec:
       name: varlibcontainers
   workspaces:
     - name: source
+    - name: buildah-git_dependency-token
+      optional: true

--- a/clustertask/buildah/templates/clustertask.yaml
+++ b/clustertask/buildah/templates/clustertask.yaml
@@ -71,7 +71,9 @@ spec:
       resources: {}
       script: >
         
-        FILE=../buildah-git_dependency-token/token 
+        token=$(ls ../buildah-git_dependency-token/)
+        
+        FILE=../buildah-git_dependency-token/$token 
 
         if [ -f "$FILE" ]; then
           echo "$FILE exists."

--- a/clustertask/buildah/templates/clustertask.yaml
+++ b/clustertask/buildah/templates/clustertask.yaml
@@ -137,5 +137,5 @@ spec:
       name: varlibcontainers
   workspaces:
     - name: source
-    - name: buildah-git_dependency-token
+    - name: buildah-git-dependency-token
       optional: true

--- a/clustertask/buildah/templates/clustertask.yaml
+++ b/clustertask/buildah/templates/clustertask.yaml
@@ -69,16 +69,16 @@ spec:
     - image: $(params.BUILDER_IMAGE)
       name: build
       resources: {}
+      env:
+        - name: WORKSPACE_BUILDAH_GIT_DEPENDENCY_TOKEN_BOUND
+          value: $(workspaces.buildah-git-dependency-token.bound)
       script: >
         
-        token=$(ls ../buildah-git_dependency-token/)
-        
-        FILE=../buildah-git_dependency-token/$token 
-
-        if [ -f "$FILE" ]; then
+        if [ "${WORKSPACE_BUILDAH_GIT_DEPENDENCY_TOKEN_BOUND}" = "true"  ]; then
+          token=$(ls ../buildah-git-dependency-token/)
+          FILE=../buildah-git-dependency-token/$token 
           echo "$FILE exists."
           GIT_DEPENDENCY_TOKEN=`cat $FILE` 
-          echo $GIT_DEPENDENCY_TOKEN
         else 
           echo "$FILE does not exist."
           GIT_DEPENDENCY_TOKEN=''


### PR DESCRIPTION
Buildah task was failing when git dependency token secret was not provided.
The secret is now mounted as an optional workspace so the task doesnt fail when secret is not needed.