### PR TITLE
bump pipeline-toolbox version

### DIFF
--- a/stakater-helm-push/helm/templates/clustertask.yaml
+++ b/stakater-helm-push/helm/templates/clustertask.yaml
@@ -40,7 +40,7 @@ spec:
           name: $(params.HELM_REG_CREDS_SECRET_NAME)  
           key: username
           optional: true
-    image: stakater/pipeline-toolbox:v0.0.20
+    image: stakater/pipeline-toolbox:v0.0.25
     name: helm-package
     command: ["/bin/bash"]
     workingDir: $(workspaces.source.path)


### PR DESCRIPTION
This will resolve the following error : 

Error: repository oci://registry-1.docker.io/bitnamicharts is an OCI registry: this feature has been marked as experimental and is not enabled by default. Please set HELM_EXPERIMENTAL_OCI=1 in your environment to use this feature