### PR TITLE
Fix action

### DIFF
--- a/.github/workflows/render_task.yaml
+++ b/.github/workflows/render_task.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   render_and_replace:
     runs-on: ubuntu-latest
-      
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-         version: v3.7.0
+          version: v3.7.0
 
       - name: Render Helm Chart
         run: |
@@ -52,6 +52,7 @@ jobs:
 
       - name: Commit Changes
         run: |
+          git pull --quiet origin main || true
           git config --global user.email "stakater@gmail.com"
           git config --global user.name "stakater-user"
           git add ${{ inputs.SUBPATH }}/rendered


### PR DESCRIPTION
Concurrent pipelines were failing because when one of the pipeline commits a change to the main before the second pipeline finishes, github throws an error of 'unmerged changes"
If we wait for one pipeline to finish before other one start and do a git pull before committing again, the error wont be thrown.
Successful pipelines:
https://github.com/AsfaMumtaz/tekton-catalog/actions